### PR TITLE
B mateo prescreening task

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.6.0"
+version = "3.6.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -821,16 +821,13 @@ pub mod pallet {
                 ));
 
                 T::Currency::resolve_creating(&staker, reward_imbalance);
-
-                Self::deposit_event(Event::<T>::Reward(staker.clone(), contract_id.clone(), era, staker_reward));
             } else {
                 let delegated_account = DelegatedAccounts::<T>::get(&staker, &contract_id).unwrap_or(staker.clone());
                 T::Currency::resolve_creating(&delegated_account, reward_imbalance);
-
-                Self::deposit_event(Event::<T>::Reward(delegated_account.clone(), contract_id.clone(), era, staker_reward));
             }
 
             Self::update_staker_info(&staker, &contract_id, staker_info);
+            Self::deposit_event(Event::<T>::Reward(staker, contract_id, era, staker_reward));
             
 
             Ok(Some(if should_restake_reward {

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -821,13 +821,17 @@ pub mod pallet {
                 ));
 
                 T::Currency::resolve_creating(&staker, reward_imbalance);
+
+                Self::deposit_event(Event::<T>::Reward(staker.clone(), contract_id.clone(), era, staker_reward));
             } else {
                 let delegated_account = DelegatedAccounts::<T>::get(&staker, &contract_id).unwrap_or(staker.clone());
                 T::Currency::resolve_creating(&delegated_account, reward_imbalance);
+
+                Self::deposit_event(Event::<T>::Reward(delegated_account.clone(), contract_id.clone(), era, staker_reward));
             }
 
             Self::update_staker_info(&staker, &contract_id, staker_info);
-            Self::deposit_event(Event::<T>::Reward(staker, contract_id, era, staker_reward));
+            
 
             Ok(Some(if should_restake_reward {
                 T::WeightInfo::claim_staker_with_restake()

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -547,12 +547,25 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
     }
 
     // last event should be Reward, regardless of restaking
-    System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
-        claimer,
-        contract_id.clone(),
-        claim_era,
-        calculated_reward,
-    )));
+    // If the claimer has a delegated account, the reward event emit it
+    match DelegatedAccounts::<TestRuntime>::get(claimer.clone(),contract_id.clone()){
+        Some(delegated_account) => {
+            System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
+                delegated_account,
+                contract_id.clone(),
+                claim_era,
+                calculated_reward,
+            )));
+        },
+        None => {
+            System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
+                claimer,
+                contract_id.clone(),
+                claim_era,
+                calculated_reward,
+            )));
+        }
+    }
 
     let (new_era, _) = final_state_current_era.staker_info.clone().claim();
     if final_state_current_era.staker_info.is_empty() {

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -547,25 +547,14 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
     }
 
     // last event should be Reward, regardless of restaking
-    // If the claimer has a delegated account, the reward event emit it
-    match DelegatedAccounts::<TestRuntime>::get(claimer.clone(),contract_id.clone()){
-        Some(delegated_account) => {
-            System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
-                delegated_account,
-                contract_id.clone(),
-                claim_era,
-                calculated_reward,
-            )));
-        },
-        None => {
-            System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
-                claimer,
-                contract_id.clone(),
-                claim_era,
-                calculated_reward,
-            )));
-        }
-    }
+    System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
+        claimer,
+        contract_id.clone(),
+        claim_era,
+        calculated_reward,
+    )));
+        
+    
 
     let (new_era, _) = final_state_current_era.staker_info.clone().claim();
     if final_state_current_era.staker_info.is_empty() {

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2249,15 +2249,10 @@ fn set_delegated_account_checks() {
         let staker = 3;
         let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
     
-        let start_era = DappsStaking::current_era();
-    
         // Prepare a scenario with different stakes
     
         assert_register(developer, &contract_id);
         assert_bond_and_stake(staker, &contract_id, 100);
-    
-        let eras_advanced = 3;
-        advance_to_era(start_era + eras_advanced);
     
         // delegate account 5 to receive rewards for account 3
         assert_ok!(DappsStaking::set_delegated_account(
@@ -2293,7 +2288,7 @@ fn set_delegated_account_checks() {
         ), Error::<TestRuntime>::NotAuthorizedToDelegate
         );
 
-        // the staker can delegate to someone else
+        // the staker can delegate to someone else or himself
         assert_ok!(DappsStaking::set_delegated_account(
             Origin::signed(staker.clone()),
             staker.clone(),

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2172,3 +2172,137 @@ pub fn set_contract_stake_info() {
         );
     })
 }
+
+#[test]
+fn claim_delegated_account() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+    
+        let first_developer = 1;
+        let second_developer = 2;
+        let first_staker = 3;
+        let second_staker = 4;
+        let first_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        let second_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x02));
+    
+        let start_era = DappsStaking::current_era();
+    
+        // Prepare a scenario with different stakes
+    
+        assert_register(first_developer, &first_contract_id);
+        assert_register(second_developer, &second_contract_id);
+        assert_bond_and_stake(first_staker, &first_contract_id, 100);
+        assert_bond_and_stake(second_staker, &first_contract_id, 45);
+    
+        // Just so ratio isn't 100% in favor of the first contract
+        assert_bond_and_stake(first_staker, &second_contract_id, 33);
+        assert_bond_and_stake(second_staker, &second_contract_id, 22);
+    
+        let eras_advanced = 3;
+        advance_to_era(start_era + eras_advanced);
+    
+        for x in 0..eras_advanced.into() {
+            assert_bond_and_stake(first_staker, &first_contract_id, 20 + x * 3);
+            assert_bond_and_stake(second_staker, &first_contract_id, 5 + x * 5);
+            advance_to_era(DappsStaking::current_era() + 1);
+        }
+    
+        // delegate account 5 to receive rewards for account 3
+        assert_ok!(DappsStaking::set_delegated_account(
+            Origin::signed(first_staker.clone()),
+            first_staker.clone(),
+            5,
+            first_contract_id
+        ));
+    
+        // Ensure that all past eras can be claimed
+        let current_era = DappsStaking::current_era();
+        for era in start_era..current_era {
+            assert_claim_staker(first_staker, &first_contract_id);
+            assert_claim_dapp(&first_contract_id, era);
+            assert_claim_staker(second_staker, &first_contract_id);
+        }
+    
+        // Shouldn't be possible to claim current era.
+        // Also, previous claim calls should have claimed everything prior to current era.
+        assert_noop!(
+            DappsStaking::claim_staker(Origin::signed(first_staker), first_contract_id.clone()),
+            Error::<TestRuntime>::EraOutOfBounds
+        );
+        assert_noop!(
+            DappsStaking::claim_dapp(
+                Origin::signed(first_developer),
+                first_contract_id,
+                current_era
+            ),
+            Error::<TestRuntime>::EraOutOfBounds
+        );
+    })
+}
+
+#[test]
+fn set_delegated_account_checks() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+    
+        let developer = 1;
+        let staker = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+    
+        let start_era = DappsStaking::current_era();
+    
+        // Prepare a scenario with different stakes
+    
+        assert_register(developer, &contract_id);
+        assert_bond_and_stake(staker, &contract_id, 100);
+    
+        let eras_advanced = 3;
+        advance_to_era(start_era + eras_advanced);
+    
+        // delegate account 5 to receive rewards for account 3
+        assert_ok!(DappsStaking::set_delegated_account(
+            Origin::signed(staker.clone()),
+            staker.clone(),
+            5,
+            contract_id
+        ));
+
+        // cannot set delegated account if no staker o delegate
+        assert_noop!(DappsStaking::set_delegated_account(
+            Origin::signed(6),
+            staker.clone(),
+            5,
+            contract_id
+        ), Error::<TestRuntime>::NotAuthorizedToDelegate
+        );
+
+        // the delegated account can delegate to someone else
+        assert_ok!(DappsStaking::set_delegated_account(
+            Origin::signed(5),
+            staker.clone(),
+            6,
+            contract_id
+        ));
+
+        // the previous delegated account cannot delegate anymore
+        assert_noop!(DappsStaking::set_delegated_account(
+            Origin::signed(5),
+            staker.clone(),
+            6,
+            contract_id
+        ), Error::<TestRuntime>::NotAuthorizedToDelegate
+        );
+
+        // the staker can delegate to someone else
+        assert_ok!(DappsStaking::set_delegated_account(
+            Origin::signed(staker.clone()),
+            staker.clone(),
+            staker.clone(),
+            contract_id
+        ));
+
+    })
+}
+
+
+

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2179,33 +2179,20 @@ fn claim_delegated_account() {
         initialize_first_block();
     
         let first_developer = 1;
-        let second_developer = 2;
         let first_staker = 3;
-        let second_staker = 4;
         let first_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
-        let second_contract_id = MockSmartContract::Evm(H160::repeat_byte(0x02));
     
         let start_era = DappsStaking::current_era();
     
         // Prepare a scenario with different stakes
     
         assert_register(first_developer, &first_contract_id);
-        assert_register(second_developer, &second_contract_id);
         assert_bond_and_stake(first_staker, &first_contract_id, 100);
-        assert_bond_and_stake(second_staker, &first_contract_id, 45);
-    
-        // Just so ratio isn't 100% in favor of the first contract
-        assert_bond_and_stake(first_staker, &second_contract_id, 33);
-        assert_bond_and_stake(second_staker, &second_contract_id, 22);
     
         let eras_advanced = 3;
         advance_to_era(start_era + eras_advanced);
-    
-        for x in 0..eras_advanced.into() {
-            assert_bond_and_stake(first_staker, &first_contract_id, 20 + x * 3);
-            assert_bond_and_stake(second_staker, &first_contract_id, 5 + x * 5);
-            advance_to_era(DappsStaking::current_era() + 1);
-        }
+
+        let free_balance_delegatee_before_claim = <TestRuntime as Config>::Currency::free_balance(&5);
     
         // delegate account 5 to receive rewards for account 3
         assert_ok!(DappsStaking::set_delegated_account(
@@ -2214,27 +2201,28 @@ fn claim_delegated_account() {
             5,
             first_contract_id
         ));
+
+        // set reward destination to free balance
+        assert_ok!(DappsStaking::set_reward_destination(
+            Origin::signed(first_staker.clone()),
+            RewardDestination::FreeBalance
+        ));
     
         // Ensure that all past eras can be claimed
         let current_era = DappsStaking::current_era();
-        for era in start_era..current_era {
+        for _ in start_era..current_era {
             assert_claim_staker(first_staker, &first_contract_id);
-            assert_claim_dapp(&first_contract_id, era);
-            assert_claim_staker(second_staker, &first_contract_id);
         }
+
+        let free_balance_delegatee_after_claim = <TestRuntime as Config>::Currency::free_balance(&5);
+        
+        // check that the free balance of delegatee has increased
+        assert!(free_balance_delegatee_after_claim > free_balance_delegatee_before_claim);
     
         // Shouldn't be possible to claim current era.
         // Also, previous claim calls should have claimed everything prior to current era.
         assert_noop!(
             DappsStaking::claim_staker(Origin::signed(first_staker), first_contract_id.clone()),
-            Error::<TestRuntime>::EraOutOfBounds
-        );
-        assert_noop!(
-            DappsStaking::claim_dapp(
-                Origin::signed(first_developer),
-                first_contract_id,
-                current_era
-            ),
             Error::<TestRuntime>::EraOutOfBounds
         );
     })

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2288,14 +2288,42 @@ fn set_delegated_account_checks() {
         ), Error::<TestRuntime>::NotAuthorizedToDelegate
         );
 
-        // the staker can delegate to someone else or himself
-        assert_ok!(DappsStaking::set_delegated_account(
+        // the staker cannot delegate to himself
+        assert_noop!(DappsStaking::set_delegated_account(
             Origin::signed(staker.clone()),
             staker.clone(),
             staker.clone(),
             contract_id
+        ), Error::<TestRuntime>::CannotDelegateToStaker);
+
+        // the delegatee cannot set the staker as delegatee
+        assert_noop!(DappsStaking::set_delegated_account(
+            Origin::signed(6),
+            staker.clone(),
+            staker.clone(),
+            contract_id
+        ), Error::<TestRuntime>::CannotDelegateToStaker);
+
+        // the delegatee can remove the delegation
+        assert_ok!(DappsStaking::remove_delegate(
+            Origin::signed(6),
+            staker.clone(),
+            contract_id
         ));
 
+        assert_ok!(DappsStaking::set_delegated_account(
+            Origin::signed(staker.clone()),
+            staker.clone(),
+            5,
+            contract_id
+        ));
+
+        // the staker can remove delegation
+        assert_ok!(DappsStaking::remove_delegate(
+            Origin::signed(staker.clone()),
+            staker.clone(),
+            contract_id
+        ));
     })
 }
 

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.6.0"
+version = "3.6.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
**Pull Request Summary**

This PR adds the ability for a staker to delegate their rewards if the latter are supposed to go to the free balance of the staker.
Also a delegated account can delegate to someone else and the staker delegate to himself.

**Check list**
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [x] relies on other tasks
- [ ] documentation changes
- [x] tests and/or benchmarks are included

**This pull request makes the following changes:**

**Adds**
- Added storage type DelegatedAccounts
- Added extrinsic to delegate rewards (set_delegated_account)
- Added unit test cheking that this new feature dont break anything and behaves correctly increasing the balance of the delegatee
- Added unit test to verify that only a staker or delegatee can delegate for the staker

**Fixes**
- In claim_staker the free balance of the delegated account its increased if RewardDestination = FreeBalance otherwise the staker free balance its increased.
- In the all function of the MemorySnapshot struct a validation was added to return a MemorySnapshot with the free balance of the delegated or the staker in order to use the assert_restake_reward util that is used in the claim_delegated_account unit test.

**Changes**
- Change mod.rs
- Change testing_utils.rs
- Change test.rs

**To-dos**
- [ ] Update benchmarks
- [ ] Update documentation
